### PR TITLE
fix: fucky field auto-derive behavior

### DIFF
--- a/src/pages/_03_devicename.rs
+++ b/src/pages/_03_devicename.rs
@@ -9,30 +9,37 @@ fn valid_entry(s: &str) -> bool {
     re.is_match(s)
 }
 
-#[allow(irrefutable_let_patterns)]
-fn autoset_hostname(en: &gtk::Entry, hostname: &str) {
+fn derive_hostname(hostname: &str) -> Option<String> {
     if hostname.is_empty() {
-        return;
+        return Some(String::new());
     }
-    let user;
-    if let first = hostname
+
+    let first = hostname
         .split_once(|c: char| c.is_whitespace())
-        .map_or(hostname, |(a, _)| a)
-        && first.chars().all(|c: char| c.is_ascii_alphanumeric())
+        .map_or(hostname, |(a, _)| a);
+    if first.chars().all(|c: char| c.is_ascii_alphanumeric())
         && first.chars().next().unwrap().is_ascii_alphabetic()
     {
-        user = first.to_ascii_lowercase();
-    } else if let last = hostname
-        .rsplit_once(|c: char| c.is_whitespace())
-        .map_or(hostname, |(_, b)| b)
-        && last.chars().all(|c: char| c.is_ascii_alphanumeric())
-        && last.chars().next().unwrap().is_ascii_alphabetic()
-    {
-        user = last.to_ascii_lowercase();
+        Some(first.to_ascii_lowercase())
     } else {
-        return;
+        let last = hostname
+            .rsplit_once(|c: char| c.is_whitespace())
+            .map_or(hostname, |(_, b)| b);
+        if last.chars().all(|c: char| c.is_ascii_alphanumeric())
+            && last.chars().next().unwrap().is_ascii_alphabetic()
+        {
+            Some(last.to_ascii_lowercase())
+        } else {
+            None
+        }
     }
-    en.set_text(&user);
+}
+
+#[allow(irrefutable_let_patterns)]
+fn autoset_hostname(en: &gtk::Entry, hostname: &str) {
+    if let Some(hostname) = derive_hostname(hostname) {
+        en.set_text(&hostname);
+    }
 }
 
 generate_page!(DeviceName {
@@ -74,7 +81,12 @@ generate_page!(DeviceName {
             self.next.set_sensitive(true);
         },
         InvalidHostname => {
-            self.error.set_visible(true);
+            if self.hostname_field_controlled {
+                SETTINGS.write().hostname.clear();
+                self.error.set_visible(false);
+            } else {
+                self.error.set_visible(true);
+            }
             self.next.set_sensitive(false);
         },
         SetHostname => {
@@ -169,4 +181,24 @@ async fn set_hostname(hostname: &str, device_name: &str) -> color_eyre::Result<(
     steps::acmd("hostnamectl", &["set-hostname", device_name, "--pretty"]).await?;
     steps::acmd("hostnamectl", &["set-hostname", hostname, "--static"]).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::derive_hostname;
+
+    #[test]
+    fn empty_input_clears_hostname() {
+        assert_eq!(derive_hostname(""), Some(String::new()));
+    }
+
+    #[test]
+    fn valid_input_derives_lowercase_hostname() {
+        assert_eq!(derive_hostname("Laptop Pro"), Some(String::from("laptop")));
+    }
+
+    #[test]
+    fn non_convertible_input_does_not_overwrite_hostname() {
+        assert_eq!(derive_hostname("!!!"), None);
+    }
 }

--- a/src/pages/_04_whoareyou.rs
+++ b/src/pages/_04_whoareyou.rs
@@ -21,30 +21,37 @@ fn valid_entry(s: &str) -> bool {
     re.is_match(s)
 }
 
-#[allow(irrefutable_let_patterns)]
-fn autoset_username(en: &gtk::Entry, fullname: &str) {
+fn derive_username(fullname: &str) -> Option<String> {
     if fullname.is_empty() {
-        return;
+        return Some(String::new());
     }
-    let user;
-    if let first = fullname
+
+    let first = fullname
         .split_once(|c: char| c.is_whitespace())
-        .map_or(fullname, |(a, _)| a)
-        && first.chars().all(|c: char| c.is_ascii_alphanumeric())
+        .map_or(fullname, |(a, _)| a);
+    if first.chars().all(|c: char| c.is_ascii_alphanumeric())
         && first.chars().next().unwrap().is_ascii_alphabetic()
     {
-        user = first.to_ascii_lowercase();
-    } else if let last = fullname
-        .rsplit_once(|c: char| c.is_whitespace())
-        .map_or(fullname, |(_, b)| b)
-        && last.chars().all(|c: char| c.is_ascii_alphanumeric())
-        && last.chars().next().unwrap().is_ascii_alphabetic()
-    {
-        user = last.to_ascii_lowercase();
+        Some(first.to_ascii_lowercase())
     } else {
-        return;
+        let last = fullname
+            .rsplit_once(|c: char| c.is_whitespace())
+            .map_or(fullname, |(_, b)| b);
+        if last.chars().all(|c: char| c.is_ascii_alphanumeric())
+            && last.chars().next().unwrap().is_ascii_alphabetic()
+        {
+            Some(last.to_ascii_lowercase())
+        } else {
+            None
+        }
     }
-    en.set_text(&user);
+}
+
+#[allow(irrefutable_let_patterns)]
+fn autoset_username(en: &gtk::Entry, fullname: &str) {
+    if let Some(username) = derive_username(fullname) {
+        en.set_text(&username);
+    }
 }
 
 generate_page!(WhoAreYou {
@@ -88,7 +95,12 @@ generate_page!(WhoAreYou {
             self.btn_next.set_sensitive(true);
         },
         InvalidUsername => {
-            self.lbl_error.set_visible(true);
+            if self.username_field_controlled {
+                SETTINGS.write().username.clear();
+                self.lbl_error.set_visible(false);
+            } else {
+                self.lbl_error.set_visible(true);
+            }
             self.btn_next.set_sensitive(false);
         }
     } => {}
@@ -187,3 +199,23 @@ generate_page!(WhoAreYou {
         },
     }
 );
+
+#[cfg(test)]
+mod tests {
+    use super::derive_username;
+
+    #[test]
+    fn empty_input_clears_username() {
+        assert_eq!(derive_username(""), Some(String::new()));
+    }
+
+    #[test]
+    fn valid_input_derives_lowercase_username() {
+        assert_eq!(derive_username("Alice Smith"), Some(String::from("alice")));
+    }
+
+    #[test]
+    fn non_convertible_input_does_not_overwrite_username() {
+        assert_eq!(derive_username("!!!"), None);
+    }
+}


### PR DESCRIPTION
update the logic for username and hostname derivation to make them more reliable, and such that the first character doesn't stay when blanking out the linked fields

experimenting with t3code btw